### PR TITLE
Fix build on Fedora and add instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Look for "Download build artifacts" on the latest successful pipeline.
 
 4. `./ppc64le_build.bash`
 
+## Fedora
+
+If you're running Fedora 30 or later, instead, you can install the dependencies with
+```
+sudo dnf install git git python bzip2 tar pkgconfig atk-devel alsa-lib-devel bison binutils brlapi-devel bluez-libs-devel bzip2-devel cairo-devel cups-devel dbus-devel dbus-glib-devel expat-devel fontconfig-devel freetype-devel gcc-c++ glib2-devel glibc gperf gtk3-devel java-1.*.0-openjdk-devel libatomic libcap-devel libffi-devel libgcc libgnome-keyring-devel libjpeg-devel libstdc++ libX11-devel libXScrnSaver-devel libXtst-devel libxkbcommon-x11-devel ncurses-compat-libs nspr-devel nss-devel pam-devel pango-devel pciutils-devel pulseaudio-libs-devel zlib httpd mod_ssl php php-cli python-psutil wdiff xorg-x11-server-Xvfb clang vim cmake pkg-config krb5-devel re2c subversion curl nodejs libuuid-devel ninja-build
+```
+
 ### /!\ You must remove the build folder before running the build script again.
 
 # ungoogled-chromium

--- a/ppc64le_build.bash
+++ b/ppc64le_build.bash
@@ -20,6 +20,8 @@ mkdir -p build/download_cache
 
 cd build/src
 
+sed -i '/-static-libstdc++/d' tools/gn/build/gen.py
+
 mkdir -p out/Default
 ./tools/gn/bootstrap/bootstrap.py --skip-generate-buildfiles -j$(nproc) -o out/Default/gn
 PATH="${PWD}/out/Default:${PATH}"


### PR DESCRIPTION
I had to patch `tools/gn/build/gen.py` in order to fix this error:
```
[niko@localhost src]$ ./tools/gn/bootstrap/bootstrap.py --skip-generate-buildfiles -j$(nproc) -o out/Default/gn 
ninja: Entering directory `/home/niko/devel/ungoogled-chromium-ppc64le/build/src/out/Release/gn_build'
[1/1] LINK gn
FAILED: gn 
clang++ -O3 -fdata-sections -ffunction-sections -Wl,--gc-sections -Wl,-strip-all -static-libstdc++ -Wl,--as-needed -pthread -o gn -Wl,--start-group tools/gn/gn_main.o base.a gn_lib.a -Wl,--end-group -ldl
/usr/bin/ld: cannot find -lstdc++
clang-8: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
Traceback (most recent call last):
  File "./tools/gn/bootstrap/bootstrap.py", line 142, in <module>
    sys.exit(main(sys.argv[1:]))
  File "./tools/gn/bootstrap/bootstrap.py", line 125, in main
    ['ninja', '-C', gn_build_dir, 'gn', '-w', 'dupbuild=err', '-j'+str(options.jobs)])
  File "/usr/lib64/python3.7/subprocess.py", line 347, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['ninja', '-C', '/home/niko/devel/ungoogled-chromium-ppc64le/build/src/out/Release/gn_build', 'gn', '-w', 'dupbuild=err', '-j32']' returned non-zero exit status 1.
```